### PR TITLE
Add create agent

### DIFF
--- a/.changeset/ten-teachers-tap.md
+++ b/.changeset/ten-teachers-tap.md
@@ -1,0 +1,5 @@
+---
+"zod-stream": patch
+---
+
+Adding simple agent utility - undocumented to expose and use for testing first

--- a/public-packages/zod-stream/src/create-agent.ts
+++ b/public-packages/zod-stream/src/create-agent.ts
@@ -1,0 +1,71 @@
+import OpenAI from "openai"
+import { z } from "zod"
+import { OAIStream, withResponseModel } from "zod-stream"
+
+import { Mode } from "./types"
+
+type CreateAgentParams = {
+  config: OpenAI.ChatCompletionCreateParams
+  mode?: Mode
+  response_model: {
+    schema: z.AnyZodObject
+    name: string
+  }
+}
+
+export type AgentInstance = ReturnType<typeof createAgent>
+export type ConfigOverride = Partial<OpenAI.ChatCompletionCreateParams>
+
+const oai = new OpenAI({
+  apiKey: process.env["OPENAI_API_KEY"],
+  organization: process.env["OPENAI_ORG_ID"]
+})
+
+/**
+ * Create a pre-configured "agent" that can be used to generate completions
+ *
+ * @param {CreateAgentParams} params
+ *
+ * @returns {AgentInstance}
+ */
+export function createAgent({ config, response_model, mode = "TOOLS" }: CreateAgentParams) {
+  const defaultAgentParams = {
+    temperature: 0.7,
+    top_p: 1,
+    frequency_penalty: 0,
+    presence_penalty: 0,
+    n: 1,
+    ...config
+  }
+
+  return {
+    /**
+     * Generate a single stream completion
+     * @param {ConfigOverride}
+     *
+     * @returns {Promise<ReadableStream<Uint8Array>> }
+     */
+    completionStream: async (
+      configOverride: ConfigOverride
+    ): Promise<ReadableStream<Uint8Array>> => {
+      const messages = [...(defaultAgentParams.messages ?? []), ...(configOverride?.messages ?? [])]
+
+      const params = withResponseModel({
+        mode,
+        response_model,
+        params: {
+          ...defaultAgentParams,
+          ...configOverride,
+          stream: true,
+          messages
+        }
+      })
+
+      const extractionStream = await oai.chat.completions.create(params)
+
+      return OAIStream({
+        res: extractionStream
+      })
+    }
+  }
+}

--- a/public-packages/zod-stream/src/index.ts
+++ b/public-packages/zod-stream/src/index.ts
@@ -2,5 +2,6 @@ import ZodStream from "./structured-stream.client"
 
 export * from "./response-model"
 export * from "./oai/stream"
+export * from "./create-agent"
 
 export default ZodStream


### PR DESCRIPTION
this is a simple utility that wraps a zod-stream implementation - ultimately the purpose is to be able to define a single instance where the schema and most of the config may be unchanged - messages defined on the instance are always prepended to all completions made on the instance.
This allows for defining a consistent identity and then using that agent in various ways. 

Only exposing now without documentation to do some testing.