### PR TITLE
adding types to the included meta

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": ["@changesets/changelog-github", { "repo": "hack-dance/island-ai" }],
   "commit": true,
   "fixed": [],
-  "linked": [],
+  "linked": [["zod-stream", "stream-hooks"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/shy-moons-shave.md
+++ b/.changeset/shy-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"zod-stream": major
+---
+
+moving the internal meta around key completino and validity into a single \_meta object on the response and adding explicit types so that consumers can reference it safely - the format has chnaged slightly from indicvidual keys on the resposne to all being wrapped up - additionalyl theres a new utility for checking completed paths

--- a/public-packages/zod-stream/examples/stream.ts
+++ b/public-packages/zod-stream/examples/stream.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai"
 import { z } from "zod"
-import ZodStream, { OAIStream, withResponseModel } from "zod-stream"
+import ZodStream, { isPathComplete, OAIStream, withResponseModel } from "zod-stream"
 
 const textBlock = `
 In our recent online meeting, participants from various backgrounds joined to discuss the upcoming tech conference. The names and contact details of the participants were as follows:
@@ -67,6 +67,8 @@ async function extractUser() {
   let result: Partial<z.infer<typeof ExtractionValuesSchema>> = {}
 
   for await (const data of extractionStream) {
+    const locationReady = isPathComplete(["location"], data)
+    console.log("location is ready?", locationReady)
     result = data
   }
 

--- a/public-packages/zod-stream/src/index.ts
+++ b/public-packages/zod-stream/src/index.ts
@@ -6,5 +6,6 @@ export * from "./oai/stream"
 export * from "./constants/modes"
 export * from "./types"
 export * from "./create-agent"
+export * from "./lib/_utils"
 
 export default ZodStream

--- a/public-packages/zod-stream/src/lib/_utils.ts
+++ b/public-packages/zod-stream/src/lib/_utils.ts
@@ -1,0 +1,20 @@
+import { ActivePath, CompletionMeta } from ".."
+
+export function isPathComplete(activePath: ActivePath, data: { _meta: CompletionMeta }): boolean {
+  const { _completedPaths } = data?._meta ?? {}
+
+  return _completedPaths.some(completedPath => {
+    if (completedPath.length !== activePath.length) {
+      return false
+    }
+
+    return completedPath.every((compPathElement, index) => {
+      const activePathElement = activePath[index]
+
+      if (compPathElement === undefined || activePathElement === undefined) {
+        return true
+      }
+      return compPathElement === activePathElement
+    })
+  })
+}

--- a/public-packages/zod-stream/src/types/index.ts
+++ b/public-packages/zod-stream/src/types/index.ts
@@ -4,6 +4,14 @@ import { JsonSchema7Type } from "zod-to-json-schema"
 
 import { MODE } from "@/constants/modes"
 
+export type ActivePath = (string | number | undefined)[]
+export type CompletedPaths = ActivePath[]
+
+export type CompletionMeta = {
+  _activePath: ActivePath
+  _completedPaths: CompletedPaths
+}
+
 export type LogLevel = "debug" | "info" | "warn" | "error"
 
 export type ClientConfig = {

--- a/public-packages/zod-stream/src/types/index.ts
+++ b/public-packages/zod-stream/src/types/index.ts
@@ -10,6 +10,7 @@ export type CompletedPaths = ActivePath[]
 export type CompletionMeta = {
   _activePath: ActivePath
   _completedPaths: CompletedPaths
+  _isValid: boolean
 }
 
 export type LogLevel = "debug" | "info" | "warn" | "error"


### PR DESCRIPTION
we include _activePath, _completedPaths and _isValid on the stream obj - im now nesting it to avoid polluting the final obj to much and adding a type so it can used without error and clear what it is when using it.

also added a little utility for checking paths - I think adding optional callbacks might be useful too - like:

onPathComplete etc.. 

I also am still trying to think through best way to include something specific for array items - maybe too much for here