### PR TITLE
Publish declaration maps so goto definition works properly

### DIFF
--- a/public-packages/evalz/tsconfig.json
+++ b/public-packages/evalz/tsconfig.json
@@ -5,7 +5,9 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "baseUrl": "."
+    "baseUrl": ".",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["tests", "src", "turbo", "tsup.config.ts", "examples"],
   "exclude": ["node_modules", "dist"]

--- a/public-packages/hooks/tsconfig.json
+++ b/public-packages/hooks/tsconfig.json
@@ -5,7 +5,9 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "baseUrl": "."
+    "baseUrl": ".",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src", "turbo", "tsup.config.ts", "tailwind.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/public-packages/llm-client/tsconfig.json
+++ b/public-packages/llm-client/tsconfig.json
@@ -5,7 +5,9 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "baseUrl": "."
+    "baseUrl": ".",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["tests", "src", "turbo", "tsup.config.ts", "examples"],
   "exclude": ["node_modules", "dist", ".eslintrc.cjs"]

--- a/public-packages/schemaStream/tsconfig.json
+++ b/public-packages/schemaStream/tsconfig.json
@@ -6,7 +6,9 @@
       "@/*": ["./src/*"]
     },
     "baseUrl": ".",
-    "types": ["bun-types"]
+    "types": ["bun-types"],
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src", "turbo", "tsup.config.ts", "tests"],
   "exclude": ["node_modules", "dist"]

--- a/public-packages/zod-stream/tsconfig.json
+++ b/public-packages/zod-stream/tsconfig.json
@@ -6,7 +6,9 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "baseUrl": "."
+    "baseUrl": ".",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["tests", "src", "turbo", "tsup.config.ts", "examples"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
👋 

I was trying to use this library a bit and understand the the types/source. It is a bit hard in VSCode because jump to definition takes you to a TS declaration file or a compiled JS file today. 

This PR adds the TS compiler option to publish declaration maps which fixes this issue, making developer experience better: https://www.typescriptlang.org/tsconfig#declarationMap

It would maybe be nice to cut a release with these enabled if its not a hassle so they actually get published.