### PR TITLE
Add support for zod validation error callback in schema stream

### DIFF
--- a/public-packages/schemaStream/README.md
+++ b/public-packages/schemaStream/README.md
@@ -253,6 +253,15 @@ class SchemaStream<T extends ZodObject<any>> {
   parse(options?: {
     stringBufferSize?: number;
     handleUnescapedNewLines?: boolean;
+    onComplete: (data: { 
+      isValid: boolean,;
+      errors: ZodError[];
+      data: data:
+          | {
+              [x: string]: any
+            }
+          | undefined
+    }) => void
   }): TransformStream;
 }
 ```

--- a/public-packages/schemaStream/README.md
+++ b/public-packages/schemaStream/README.md
@@ -335,6 +335,7 @@ const parser = new SchemaStream(schema, {
 
 - `stringBufferSize`: Size of the buffer for string values (default: 0)
 - `handleUnescapedNewLines`: Handle unescaped newlines in JSON (default: true)
+-  onSchemaInvalid: Callback that will return any zod errors found during validation if provided schema is strict. (default: () =>)
 
 ### Schema Stub Utility
 

--- a/public-packages/schemaStream/README.md
+++ b/public-packages/schemaStream/README.md
@@ -335,7 +335,7 @@ const parser = new SchemaStream(schema, {
 
 - `stringBufferSize`: Size of the buffer for string values (default: 0)
 - `handleUnescapedNewLines`: Handle unescaped newlines in JSON (default: true)
--  onSchemaInvalid: Callback that will return any zod errors found during validation if provided schema is strict. (default: () =>)
+-  onSchemaInvalid: Callback that will return any zod errors found during validation if provided schema is strict. (default: (err: ZodError) => {})
 
 ### Schema Stub Utility
 

--- a/public-packages/schemaStream/src/utils/streaming-json-parser.ts
+++ b/public-packages/schemaStream/src/utils/streaming-json-parser.ts
@@ -70,7 +70,6 @@ export class SchemaStream {
   private activePath: (string | number | undefined)[] = []
   private completedPaths: (string | number | undefined)[][] = []
   private onKeyComplete?: OnKeyCompleteCallback
-  private isStrictSchema: Boolean
 
   /**
    * Constructs a new instance of the `SchemaStream` class.
@@ -90,7 +89,6 @@ export class SchemaStream {
     this.schemaType = schema
     this.schemaInstance = this.createBlankObject(schema, defaultData, typeDefaults)
     this.onKeyComplete = onKeyComplete
-    this.isStrictSchema = this.schemaType._def.unknownKeys === "strict"
   }
 
   /**

--- a/public-packages/schemaStream/src/utils/streaming-json-parser.ts
+++ b/public-packages/schemaStream/src/utils/streaming-json-parser.ts
@@ -1,4 +1,4 @@
-import { isNil, lensPath, set, view } from "ramda"
+import { lensPath, set, view } from "ramda"
 import { z, ZodObject, ZodOptional, ZodRawShape, ZodTypeAny } from "zod"
 
 import JSONParser from "./json-parser"

--- a/public-packages/schemaStream/tests/zod-types.test.ts
+++ b/public-packages/schemaStream/tests/zod-types.test.ts
@@ -23,8 +23,8 @@ async function runTest<T extends ZodRawShape>(schema: ZodObject<T>, jsonData: ob
   })
 
   const stream = parser.parse({
-    onSchemaInvalid: zodError => {
-      errors = zodError.errors
+    onComplete: ({ errors: validationErrors }) => {
+      errors = validationErrors
     }
   })
 


### PR DESCRIPTION
Was noodling on https://github.com/hack-dance/island-ai/issues/78 a bit last night:

While we don't want to defacto throw validation errors (the point of the package after all is type-safety), we could provide a simple callback once the stream ends to say "hey, here's the errors we found" if the zod schema provided is strict.

This gives the caller the power to do whatever they want but they now have both the completed data via the stream *and* validation errors they may or may not care about.