### PR TITLE
Loosen peer dependency on openai

### DIFF
--- a/.changeset/light-taxis-scream.md
+++ b/.changeset/light-taxis-scream.md
@@ -1,0 +1,5 @@
+---
+"llm-polyglot": patch
+---
+
+Adjust OAI Peer dep

--- a/public-packages/llm-client/package.json
+++ b/public-packages/llm-client/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.22.0",
     "@google/generative-ai": "^0.21.0",
-    "openai": "4.47.1"
+    "openai": "^4.47.1"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.22.0",


### PR DESCRIPTION
Thanks for releasing this library! I'm using InstructorJS and interested in comparing some Anthropic and Google models for our use cases.

### Changes in this PR

Currently, package.json specifies a `peerDependency` for the `openai` library at exactly version `4.47.1`. This PR loosens the dependency to any version of the library backward-compatible with 4.47.1. The `openai-node` repo describes their SemVer policy here: https://github.com/openai/openai-node?tab=readme-ov-file#semantic-versioning

Without this change you get, for example:

```
~/dev/myrepo $ npm i llm-polyglot
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: myrepo@0.1.0
npm error Found: openai@4.77.0
npm error node_modules/openai
npm error   openai@"^4.77.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer openai@"4.47.1" from llm-polyglot@2.3.1
npm error node_modules/llm-polyglot
npm error   llm-polyglot@"*" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/jason/.npm/_logs/2024-12-21T00_46_43_123Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/jason/.npm/_logs/2024-12-21T00_46_43_123Z-debug-0.log
```

### Additional related changes

I figured this was a pretty safe change given SemVer rules. I didn't make any further changes, but here are a few "while I was in there" notes 😄 

Since I was looking at the peerDependencies list, I checked that the `@google/generative-ai` one is up-to-date with their latest release ✅ 

The `@anthropic-ai/sdk` peerDependency is specified to `^0.22.0`, which is not compatible with [their latest SDK](https://www.npmjs.com/package/@anthropic-ai/sdk?activeTab=versions). It could be worth bumping and testing that, but I haven't looked into the actual changelog and whether it has meaningful changes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Loosen `openai` peer dependency in `package.json` to allow backward-compatible versions, resolving npm installation errors.
> 
>   - **Dependencies**:
>     - Loosen `openai` peer dependency in `package.json` from `4.47.1` to `^4.47.1` to allow backward-compatible versions.
>   - **Context**:
>     - Resolves npm installation errors due to strict versioning of `openai` dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hack-dance%2Fisland-ai&utm_source=github&utm_medium=referral)<sup> for 60a54f46df0c2307150f6b74c256d116bb5e7764. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->