### PR TITLE
[llm-polyglot] Add convenience flag for applying grounding to Gemini chat completions

### DIFF
--- a/.changeset/dull-zoos-cry.md
+++ b/.changeset/dull-zoos-cry.md
@@ -1,5 +1,5 @@
 ---
-"llm-polyglot": minor
+"llm-polyglot": patch
 ---
 
 Added convenience flag for grounding support within Gemini

--- a/.changeset/dull-zoos-cry.md
+++ b/.changeset/dull-zoos-cry.md
@@ -1,0 +1,5 @@
+---
+"llm-polyglot": minor
+---
+
+Added convenience flag for grounding support within Gemini

--- a/.changeset/dull-zoos-cry.md
+++ b/.changeset/dull-zoos-cry.md
@@ -1,5 +1,5 @@
 ---
-"llm-polyglot": patch
+"llm-polyglot": minor
 ---
 
 Added convenience flag for grounding support within Gemini

--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ const client = createLLMClient({
    - Streaming support
    - Function calling
    - Optional OpenAI compatibility mode
+   - Grounding (i.e. Google Search) support
 
 3. **OpenAI**
    - Direct SDK proxy

--- a/public-packages/llm-client/README.md
+++ b/public-packages/llm-client/README.md
@@ -187,6 +187,21 @@ const cacheResponse = await googleClient.cacheManager.create({
     })
 ```
 
+#### Grounding
+Grounding is a feature specific to Gemini that allows you to use Google Search to retrieve context for your model. This can be useful for answering questions that require real-time data.
+
+To use Grounding you need to set the `groundingThreshold` option when calling client.chat.completions.create. This is a number between 0 and 1 that determines the threshold for when the model will use the cached context.
+
+```typescript
+const completion = await client.chat.completions.create({
+  model: "gemini-1.5-flash-latest",
+  messages: [
+    { role: "user", content: "Give me the best ice cream places in Boston" }
+  ],
+  groundingThreshold: 0.7
+});
+```
+
 #### Gemini OpenAI Compatibility
 
 Gemini does support [OpenAI compatibility](https://ai.google.dev/gemini-api/docs/openai#node.js) for it's Node client but given that it's in beta and it has some limitations around structured output and images we're not using it directly in this library.

--- a/public-packages/llm-client/src/providers/google/index.ts
+++ b/public-packages/llm-client/src/providers/google/index.ts
@@ -27,8 +27,6 @@ import { CachedContentUpdateParams, GoogleAICacheManager } from "@google/generat
 import { ClientOptions } from "openai"
 import { isEmpty } from "ramda"
 
-const DEFAULT_GROUNDING_THRESHOLD = 0.7
-
 export class GoogleProvider extends GoogleGenerativeAI implements OpenAILikeClient<"google"> {
   public apiKey: string
   public logLevel: LogLevel = (process.env?.["LOG_LEVEL"] as LogLevel) ?? "info"

--- a/public-packages/llm-client/src/providers/google/index.ts
+++ b/public-packages/llm-client/src/providers/google/index.ts
@@ -65,7 +65,7 @@ export class GoogleProvider extends GoogleGenerativeAI implements OpenAILikeClie
    */
   private transformParams(params: GoogleChatCompletionParams): GenerateContentRequest {
     let function_declarations: FunctionDeclarationsTool[] = []
-    const allowedFunctionNames: string[] = ["googleSearchRetrieval"]
+    const allowedFunctionNames: string[] = []
     const mappedTools: Tool[] = []
 
     const { systemMessages, nonSystemMessages } = params.messages.reduce<{

--- a/public-packages/llm-client/src/providers/google/index.ts
+++ b/public-packages/llm-client/src/providers/google/index.ts
@@ -252,14 +252,13 @@ export class GoogleProvider extends GoogleGenerativeAI implements OpenAILikeClie
       const googleParams = this.transformParams(params)
 
       const isGroundingEnabled = params?.groundingThreshold !== undefined
-      const groundingThreshold = params?.groundingThreshold ?? DEFAULT_GROUNDING_THRESHOLD
 
       if (isGroundingEnabled) {
         googleParams.tools?.push({
           googleSearchRetrieval: {
             dynamicRetrievalConfig: {
               mode: DynamicRetrievalMode.MODE_DYNAMIC,
-              dynamicThreshold: groundingThreshold
+              dynamicThreshold: params.groundingThreshold
             }
           }
         })

--- a/public-packages/llm-client/src/types/index.ts
+++ b/public-packages/llm-client/src/types/index.ts
@@ -67,6 +67,7 @@ export type GoogleChatCompletionParamsStream = Omit<
   additionalProperties?: {
     cacheName?: string
   }
+  groundingThreshold?: number
   model: GeminiGenerativeModels | string
 }
 
@@ -80,6 +81,7 @@ export type GoogleChatCompletionParamsNonStream = Omit<
   additionalProperties?: {
     cacheName?: string
   }
+  groundingThreshold?: number
   model: GeminiGenerativeModels
 }
 

--- a/public-packages/llm-client/tests/google.test.ts
+++ b/public-packages/llm-client/tests/google.test.ts
@@ -208,7 +208,5 @@ test("Chat with search", async () => {
     groundingThreshold: 0.7
   })
 
-  console.log(completion?.choices?.[0].message.content)
-
   expect(completion?.choices?.[0].message.content).toMatch(/J.P. Licks/i)
 })

--- a/public-packages/llm-client/tests/google.test.ts
+++ b/public-packages/llm-client/tests/google.test.ts
@@ -195,7 +195,7 @@ describe(`LLMClient Gemini Provider`, () => {
   })
 })
 
-test.only("Chat with search", async () => {
+test("Chat with search", async () => {
   const completion = await googleClient.chat.completions.create({
     model: "gemini-1.5-flash-latest",
     messages: [

--- a/public-packages/llm-client/tests/google.test.ts
+++ b/public-packages/llm-client/tests/google.test.ts
@@ -194,3 +194,21 @@ describe(`LLMClient Gemini Provider`, () => {
     expect(completion?.choices?.[0].message.content).toMatch(/Montana/i)
   })
 })
+
+test.only("Chat with search", async () => {
+  const completion = await googleClient.chat.completions.create({
+    model: "gemini-1.5-flash-latest",
+    messages: [
+      {
+        role: "user",
+        content: "Give me some of the best ice cream places in Boston"
+      }
+    ],
+    max_tokens: 1000,
+    groundingThreshold: 0.7
+  })
+
+  console.log(completion?.choices?.[0].message.content)
+
+  expect(completion?.choices?.[0].message.content).toMatch(/J.P. Licks/i)
+})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `groundingThreshold` option to `GoogleProvider` for Gemini chat completions, updates documentation, and adds a test for grounding functionality.
> 
>   - **Feature**:
>     - Adds `groundingThreshold` option to `GoogleProvider` in `index.ts` for Gemini chat completions, enabling Google Search grounding.
>     - Default `groundingThreshold` set to 0.7.
>   - **Documentation**:
>     - Updates `README.md` and `public-packages/llm-client/README.md` to include grounding feature details.
>   - **Tests**:
>     - Adds test `Chat with search` in `google.test.ts` to verify grounding functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hack-dance%2Fisland-ai&utm_source=github&utm_medium=referral)<sup> for 7243a9360d6e36ec73b84a057cc0b994f2aaf3e0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->