### PR TITLE
fix(evalz): add type assertion for instructor response in createEvaluator

### DIFF
--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { BrandGithub, BrandLinkedin, BrandTwitter } from "@mynaui/icons-react"
+import { Github, Linkedin, Twitter } from "@mynaui/icons-react"
 
 export const Footer = () => {
   return (
@@ -18,13 +18,13 @@ export const Footer = () => {
 
           <nav className="text-muted-foreground flex items-center gap-4">
             <Link href="https://www.linkedin.com/company/hack-dance" target="_blank">
-              <BrandLinkedin className="size-5" />
+              <Linkedin className="size-5" />
             </Link>
             <Link href="https://www.github.com/hack-dance/island-ai" target="_blank">
-              <BrandGithub className="size-5" />
+              <Github className="size-5" />
             </Link>
             <Link href="https://www.twitter.com/dimitrikennedy/" target="_blank">
-              <BrandTwitter className="size-5" />
+              <Twitter className="size-5" />
             </Link>
           </nav>
         </div>

--- a/public-packages/evalz/src/evaluators/index.ts
+++ b/public-packages/evalz/src/evaluators/index.ts
@@ -65,7 +65,7 @@ export function createEvaluator<T extends ResultsType>({
         })
 
         return {
-          score: response["score"],
+          score: (response as z.infer<typeof scoringSchema>)["score"],
           item
         }
       })


### PR DESCRIPTION
The instructor client's response type does not include 'score' in its base type signature, causing TS7053 when accessing response['score']. Cast to z.infer<typeof scoringSchema> since the response_model schema guarantees the shape.

Created this PR to address the build error in the `zod-stream` fix