### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,13 @@ jobs:
     if: github.repository == 'hack-dance/island-ai' && github.event.pull_request.merged == true && (startsWith(github.head_ref, 'changeset-release/main') || startsWith(github.head_ref, '_publish-trigger'))
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
 
     name: Publish packages
     runs-on: ubuntu-latest
     environment: Publish
     env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: true
@@ -39,17 +39,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Update npm
+        run: npm install --global npm@latest
 
       - name: Publish packages & create release
         id: changesets
@@ -60,4 +57,3 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Purpose

Replace the expired long-lived npm token path with npm trusted publishing so the pending major releases can publish through GitHub OIDC.

## Changes

- grant the publish job `id-token: write`
- configure npmjs.org through `setup-node`
- guarantee a current npm CLI with trusted-publishing support
- remove `NPM_TOKEN` and custom `.npmrc` wiring

## Verification

- `publish.yml` parses as valid YAML
- npm registry confirms the five target versions remain unpublished

## Required npm setup

Configure GitHub Actions trusted publishing for `hack-dance/island-ai`, workflow `publish.yml`, environment `Publish`, with `npm publish` allowed on:

- `schema-stream`
- `zod-stream`
- `stream-hooks`
- `llm-polyglot`
- `evalz`
