### PR TITLE
ci: use Node bundled npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Update npm
-        run: npm install --global npm@latest
-
       - name: Publish packages & create release
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Purpose

Fix the OIDC publish failure caused by reinstalling npm globally on the GitHub runner.

## Change

Use Node 24.18.0's bundled npm 11.16.0 instead of overwriting it. The bundled CLI already satisfies npm trusted publishing's version requirement and includes the complete sigstore dependency tree.

## Verification

- publish workflow reached OIDC successfully in run 29066132124
- all five package builds passed
- failure was isolated to MODULE_NOT_FOUND for sigstore in the globally reinstalled npm
- publish.yml parses as valid YAML