### PR TITLE
ci: use supported npm publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,18 @@
 name: Publish
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  push:
+    branches:
+      - main
+    paths:
+      - "public-packages/*/package.json"
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions: {}
 jobs:
   publish:
-    if: github.repository == 'hack-dance/island-ai' && github.event.pull_request.merged == true && (startsWith(github.head_ref, 'changeset-release/main') || startsWith(github.head_ref, '_publish-trigger'))
+    if: github.repository == 'hack-dance/island-ai'
     permissions:
       contents: write
       id-token: write
@@ -21,7 +24,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_REMOTE_ONLY: true
+      TURBO_CACHE: remote:rw
     
 
     steps:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -23,8 +23,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_REMOTE_ONLY: true
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      TURBO_CACHE: remote:rw
 
     steps:
       - name: Checkout code
@@ -51,4 +50,3 @@ jobs:
           version: bun run version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Purpose

Run npm trusted publishing from a GitHub OIDC identity npm supports. The previous pull_request_target trigger consistently reached OIDC but npm rejected it with E404 (upstream npm/cli#8739).

## Changes

- publish on main changes to public package manifests, which is what a Changesets version PR merge produces
- allow manual workflow dispatch for recovery and controlled retries
- retain publish.yml and the Publish environment so all five existing trusted-publisher registrations remain valid
- remove the unused stale npm token from the version-PR workflow
- replace deprecated TURBO_REMOTE_ONLY with TURBO_CACHE=remote:rw

## Verification

- both release workflows parse as valid YAML
- OIDC detection, all five package builds, and npm provenance tooling passed in run 29066353083
- no target package version has been published